### PR TITLE
Nav

### DIFF
--- a/src/header/Header.js
+++ b/src/header/Header.js
@@ -5,9 +5,18 @@ import './Header.scss'
 
 const Header = () => (
   <header>
-    <nav>
-      <Link to ='/'>Nate Suri</Link>
-    </nav>
+    <div className='navbar'>
+      <nav className='leftNav'>
+        <Link to ='/'>Nate Suri</Link>
+      </nav>
+      <nav className='rightNav'>
+        <Link to ='/'>About</Link>
+        <Link to ='/'>Projects</Link>
+        <Link to ='/'>Skills</Link>
+        <Link to ='/'>Contact</Link>
+        <Link to ='/'>Resume</Link>
+      </nav>
+    </div>
   </header>
 )
 

--- a/src/header/Header.js
+++ b/src/header/Header.js
@@ -11,9 +11,9 @@ const Header = () => (
       </nav>
       <nav className='rightNav'>
         <Link to ='/'>About</Link>
-        <Link to ='/'>Projects</Link>
-        <Link to ='/'>Skills</Link>
-        <Link to ='/'>Contact</Link>
+        <Link to ='/projects'>Projects</Link>
+        <Link to ='/skills'>Skills</Link>
+        <Link to ='/contact'>Contact</Link>
         <Link to ='/'>Resume</Link>
       </nav>
     </div>

--- a/src/header/Header.scss
+++ b/src/header/Header.scss
@@ -1,1 +1,40 @@
 @import '../colors.scss';
+
+header {
+  background: $nav-color;
+  height: 8vh;
+}
+
+.navbar {
+  height: 100%;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-around;
+  margin: 0 300px;
+}
+
+.leftNav {
+  flex-grow: 1;
+  margin: 0 0 0 10px;
+  font-size: 1.25rem;
+  font-weight: 600;
+  // width: 50%;
+}
+
+.rightNav {
+  width: 40%;
+  display: flex;
+  flex-direction: row;
+  flex-grow: 0;
+  justify-content: space-around;
+  margin: 0 10px 0 0;
+  font-size: 1rem;
+  font-weight: 500;
+}
+
+a {
+  color: $white-font;
+  text-decoration: none;
+  // margin: 0 50px;
+}


### PR DESCRIPTION
This pull request creates a working Nav for the portfolio site, and adds minimal styling to mimic current portfolio site. 

Old site (the one that will be replaced by this site):
<img width="1680" alt="Old Site" src="https://user-images.githubusercontent.com/35355802/54628485-08602780-4a4c-11e9-912b-e1a0e1d8c0cf.png">

New Site (only nav, as of this PR):
<img width="1680" alt="New Site - Nav" src="https://user-images.githubusercontent.com/35355802/54628488-0b5b1800-4a4c-11e9-9c70-c4e3ed73a97d.png">
